### PR TITLE
fix: linux command changes

### DIFF
--- a/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -120,7 +120,7 @@ check the backtrace number mentioned in the text below the listing
 -->
 
 ```console
-$ RUST_BACKTRACE=1 cargo run
+$ export RUST_BACKTRACE=1; cargo run
 thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 99', src/main.rs:4:5
 stack backtrace:
    0: rust_begin_unwind

--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -173,7 +173,7 @@ que contenga la palabra "to" en minúsculas:
 establecido en `1` pero con la misma consulta `to`.
 
 ```console
-$ IGNORE_CASE=1 cargo run -- to poem.txt
+$ export IGNORE_CASE=1; cargo run -- to poem.txt
 ```
 
 Si estás usando PowerShell, deberás establecer la variable de entorno y


### PR DESCRIPTION
Corregi el comando de linux que estaba mal 
Correciones:
- **$ RUST_BACKTRACE=1 cargo run** (este es el comando equivocado)
- **$ export RUST_BACKTRACE=1; cargo run** (este es el comando corregido)
- **$ IGNORE_CASE=1 cargo run -- to poem.txt** (este es el comando equivocado)
- **$ export IGNORE_CASE=1; cargo run -- to poem.txt** (este es el comando corregido)
