### PR TITLE
Fix:error de traducción en el capitulo 6.2

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -239,7 +239,7 @@ especial que coincide con cualquier valor y no se vincula a ese valor. Esto le
 dice a Rust que no vamos a usar el valor, por lo que Rust no nos advertirá
 sobre una variable no utilizada.
 
-Vamos a cambiar las reglas del juego. Ahora, si sacas un 3 o un 7, debes tirar
+Vamos a cambiar las reglas del juego. Ahora, si sacas un número diferente de un 3 o un 7 debes tirar
 de nuevo. Ya no necesitamos usar el valor general, por lo que puede cambiar
 nuestro código para usar `_` en lugar de la variable llamada `other`:
 


### PR DESCRIPTION
Observe un error de traduccion en el capítulo 6.2 (el operador de control de flujo match) específicamente en la sección de "Patrones de captura y el marcador de posición". Este error ocurre en el párrafo:

![esbookerr](https://github.com/RustLangES/rust-book-es/assets/126206823/764d05f1-3909-4564-a10e-d31b01de4188)

He realizado una modificación para que se comprenda mejor; el resultado fue:

![result](https://github.com/RustLangES/rust-book-es/assets/126206823/e5b3fe5c-a165-4895-845b-47edbf674282)

Para esto he cambiado el archivo ``/src/ch06-02-match.md`` en la linea 242