### PR TITLE
Correccion de la palabra generico en singular

### DIFF
--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -45,7 +45,7 @@ Cuando usamos un parámetro en el cuerpo de la función, tenemos que declarar el
 nombre del parámetro en la firma para que el compilador sepa qué significa ese
 nombre. De manera similar, cuando usamos un nombre de parámetro de tipo en la
 firma de una función, tenemos que declarar el nombre del parámetro de tipo
-antes de usarlo. Para definir la función genérico `largest`, coloque las
+antes de usarlo. Para definir un genérico en la función `largest`, coloque las
 declaraciones de nombre de tipo dentro de corchetes angulares, `<>`, entre el
 nombre de la función y la lista de parámetros, así:
 
@@ -59,7 +59,7 @@ de tipo `T`. La función `largest` devolverá una referencia a un valor del mism
 tipo `T`.
 
 El listado 10-5 muestra la definición de la función `largest` combinada usando
-el tipo de datos genérico en su firma. La lista también muestra cómo podemos
+el tipo de datos genéricos en su firma. La lista también muestra cómo podemos
 llamar a la función con un slice de valores `i32` o valores `char`. Tenga en
 cuenta que este código aún no se compilará, pero lo arreglaremos más adelante
 en este capítulo.
@@ -155,12 +155,12 @@ para que `x` e `y` puedan ser valores de tipos diferentes</span>
 ¡Ahora todas las instancias de `Point` que se muestran se permiten! Puede usar
 tantos parámetros de tipo genérico en una definición como desee, pero usar más
 de unos pocos hace que su código sea difícil de leer. Si encuentra que necesita
-muchos tipos genérico en su código, podría indicar que su código necesita
+muchos tipos genéricos en su código, podría indicar que su código necesita
 reestructurarse en piezas más pequeñas.
 
 ### Definiciones En Enum
 
-Como hicimos con structs, podemos definir enums para contener tipos genérico en
+Como hicimos con structs, podemos definir enums para contener tipos genéricos en
 sus variantes. Echemos otro vistazo al enum `Option<T>` que la biblioteca
 estándar proporciona, que usamos en el Capítulo 6:
 
@@ -178,7 +178,7 @@ Al usar el enum `Option<T>`, podemos expresar el concepto abstracto de un valor
 opcional, y porque `Option<T>` es genérico, podemos usar esta abstracción sin
 importar el tipo del valor opcional.
 
-Los enums también pueden usar múltiples tipos genérico. La definición del enum
+Los enums también pueden usar múltiples tipos genéricos. La definición del enum
 `Result` que usamos en el Capítulo 9 es un ejemplo:
 
 ```rust
@@ -200,11 +200,11 @@ usamos para abrir un archivo en el listado 9-3, donde `T` se llenó con el tipo
 
 Cuando reconoces situaciones en tu código con múltiples definiciones de struct
 o enum que difieren solo en los tipos de los valores que contienen, puedes
-evitar la duplicación usando tipos genérico en su lugar.
+evitar la duplicación usando tipos genéricos en su lugar.
 
 ### Definiciones En Method
 
-Podemos implementar métodos en structs y enums y usar tipos genérico en sus
+Podemos implementar métodos en structs y enums y usar tipos genéricos en sus
 definiciones también. El listado 10-9 muestra el struct `Point<T>` que
 definimos en el listado 10-6 con un método llamado `x` implementado en él.
 
@@ -231,7 +231,7 @@ escritos dentro de un `impl` que declara el tipo genérico se definirán en
 cualquier instancia del tipo, sin importar qué tipo concreto termine
 sustituyendo al tipo genérico.
 
-También podemos especificar restricciones en los tipos genérico al definir
+También podemos especificar restricciones en los tipos genéricos al definir
 métodos en el tipo. Por ejemplo, podríamos implementar métodos solo en
 instancias de `Point<T>` con un tipo `f32` concreto en lugar de en instancias
 de `Point<T>` con cualquier tipo genérico. En el listado 10-10 usamos el tipo
@@ -256,7 +256,7 @@ matemáticas que solo están disponibles para tipos de punto flotante.
 
 Los parámetros de tipo genérico en una definición de struct no siempre son los
 mismos que los que usas en las firmas de métodos de ese mismo struct. El
-listado 10-11 usa los tipos genérico `X1` e `Y1` para el struct `Point` y `X2`
+listado 10-11 usa los tipos genéricos `X1` e `Y1` para el struct `Point` y `X2`
 `Y2` para la firma del método `mixup` para hacer el ejemplo más claro. El
 método crea una nueva instancia de `Point` con el valor `x` del `self` `Point`
 (de tipo `X1`) y el valor `y` del `Point` pasado (de tipo `Y2`).
@@ -267,7 +267,7 @@ método crea una nueva instancia de `Point` con el valor `x` del `self` `Point`
 {{#rustdoc_include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-11/src/main.rs}}
 ```
 
-<span class="caption">Listado 10-11: Un método que usa diferentes tipos genérico
+<span class="caption">Listado 10-11: Un método que usa diferentes tipos genéricos
 de la definición de su struct</span>
 
 En `main`, hemos definido un `Point` que tiene un `i32` para `x` (con valor `5`)
@@ -288,7 +288,7 @@ método.
 ### Rendimiento de código usando genéricos
 
 Quizás te estés preguntando si hay un costo de rendimiento al usar parámetros
-de tipo genérico. La buena noticia es que usar tipos genérico no hará que tu
+de tipo genérico. La buena noticia es que usar tipos genéricos no hará que tu
 programa se ejecute más lento de lo que lo haría con tipos concretos.
 
 Rust logra esto realizando _monomorfización_ del código usando genéricos en


### PR DESCRIPTION
Correccion de multiples ocasiones donde la palabra generico aparece en singular cuando se deberia usar en plural