### PR TITLE
Update ch10-02-traits.md

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -98,7 +98,7 @@ binario podría usar nuestra biblioteca de `aggregator`:
 {{#rustdoc_include ../listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/src/main.rs}}
 ```
 
-Este código imprime `New article available! horse_ebooks: of course, as you
+Este código imprime `1 new tweet: horse_ebooks: of course, as you
 probably already know, people`.
 
 Otros crates que dependen de nuestro crate `aggregator` pueden usar el trait


### PR DESCRIPTION
Fix typing error (wrong code result)

Example code states: 
println!("1 new tweet: {}", tweet.summarize());

So there's an obvious error when explaining that "println!" result.

