### PR TITLE
ci(mdbook-epub): change binary version to fix EPUB generation issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         curl -sSL https://github.com/catppuccin/mdBook/releases/download/v0.1.1/mdbook-catppuccin-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "$(pwd)/bin" >> ${GITHUB_PATH}
     - name: Install mdbook-epub backend
-      run: cargo install mdbook-epub --root .
+      run: cargo install --git https://github.com/blandger/mdbook-epub/ --branch add_links_preprocessing --force --root .
     - name: Report versions
       run: |
         rustup --version
@@ -71,7 +71,7 @@ jobs:
         curl -sSL https://github.com/RustLangES/mdBook/releases/download/v0.4.36-localization-v0.4/mdbook-v0.4.36-localization-v0.4-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "$(pwd)/bin" >> ${GITHUB_PATH}
     - name: Install mdbook-epub backend
-      run: cargo install mdbook-epub --root .
+      run: cargo install --git https://github.com/blandger/mdbook-epub/ --branch add_links_preprocessing --force --root .
     - name: Install mdbook-trpl-note
       run: cargo install --path packages/mdbook-trpl-note
     - name: Install mdbook-trpl-listing

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -38,7 +38,7 @@ jobs:
           echo "$(pwd)/bin" >> ${GITHUB_PATH}
       - name: Install mdbook-epub backend
         run: |
-          cargo install mdbook-epub --root .
+          cargo install --git https://github.com/blandger/mdbook-epub/ --branch add_links_preprocessing --force --root .
       - name: Build with mdBook
         run: mdbook build
       - name: Build with mdBook-epub

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -68,7 +68,7 @@ jobs:
           echo "$(pwd)/bin" >> ${GITHUB_PATH}
       - name: Install mdbook-epub backend
         run: |
-          cargo install mdbook-epub --root .
+          cargo install --git https://github.com/blandger/mdbook-epub/ --branch add_links_preprocessing --force --root .
       - name: Build with mdBook
         run: mdbook build
       - name: Build with mdBook-epub

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -200,7 +200,7 @@
                     <h1 class="menu-title">{{ book_title }}</h1>
 
                     <div class="right-buttons">
-                        <a href="{{ path_to_root}}{{ book_title }}.epub" title="Download to EPUB" aria-label="Download to EPUB">
+                        <a href="{{ path_to_root}}{{ book_title }}-es-0.0.1.epub" title="Download to EPUB" aria-label="Download to EPUB">
                             <i id="epub-button" class="fa fa-book"></i> <!--"fa fa-book""fa fa-leanpub" </i> -->
                         </a>
                         {{#if print_enable}}


### PR DESCRIPTION
📚 Fix EPUB Snippets Export Issue (mdbook-epub)

**Context:**
This PR addresses issue #93, where code snippets were missing in the generated EPUB file of the book.

**Problem:**
When exporting the book using mdbook-epub v0.4.48, the resulting .epub file does not include the code snippets. In other words, this version of mdbook-epub ignore specific features of mdbook and custom helpers like `{{#include /path/to/file.md}}` or `{{#rustdoc_include path}`See [preprocessors](https://rust-lang.github.io/mdBook/for_developers/preprocessors.html) and 
[mdbook-specific-features](https://rust-lang.github.io/mdBook/format/mdbook.html#mdbook-specific-features) for more context.
This becomes evident when opening the EPUB file in readers like epub-reader.online and navigating to chapters such as Chapter 2 — "Programando un juego de adivinanzas".

**Note:**
Previously, the generated file had  name like `El Lenguaje de Programación Rust.epub`.  With the change mdbook-epub binary, the output filename now matches with `El Lenguaje de Programación Rust-es-0.0.1.epub`.


**Addtional Context:**
[https://github.com/Michael-F-Bryan/mdbook-epub/commit/06013abacd1895f2e0935d138641a7aa9c8ce952](https://github.com/Michael-F-Bryan/mdbook-epub/commit/06013abacd1895f2e0935d138641a7aa9c8ce952)
[https://github.com/Michael-F-Bryan/mdbook-epub/issues/30](https://github.com/Michael-F-Bryan/mdbook-epub/issues/30)
