### PR TITLE
fix: Remove extra backtick breaking markdown formatting in ch04-02

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -238,7 +238,7 @@ for it to be borrowed from
 
 Se traduciría algo así como:
 
-````text
+```text
 el tipo de retorno de la función contiene un valor prestado, pero no hay ningún 
 valor que pueda ser prestado
 ```


### PR DESCRIPTION
This PR removes an extra backtick (`) character that was causing subsequent text on the page to be rendered incorrectly as a code block. This fix restores the intended Markdown formatting and improves readability.

This is what causes that extra backtick:
![image](https://github.com/user-attachments/assets/29278c4e-7daa-44bd-8d88-f91787b69cab)
