### PR TITLE
fix: corrige traducción en ch02-00 (shadowing)

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -703,7 +703,7 @@ anterior de `guess` con uno nuevo. Este concepto en Rust se le conoce como
 _Shadowing_, nos permite volver a usar el nombre de la variable `guess`
 en lugar de obligarnos a crear dos variables únicas, como `guess_str`
 y `guess`, por ejemplo. Lo cubriremos con más detalle en el
-[Capítulo 3][shadowing]<!-- ignore -->, pero por ahora, sé que esta
+[Capítulo 3][shadowing]<!-- ignore -->, pero por ahora, debe saber que esta
 característica se usa a menudo cuando desea convertir un valor de un tipo a
 otro tipo.
 


### PR DESCRIPTION
## Resumen

En `src/ch02-00-guessing-game-tutorial.md` la traducción actual dice:

> ...pero por ahora, sé que esta característica se usa a menudo...

El original en inglés es:

> ...but for now, know that this feature is often used...

El "know that" del original es un imperativo dirigido al lector. "Sé que" en español es ambiguo (puede leerse como 1ª persona de "saber" o como "ser") y pierde ese sentido. Lo cambio a "debe saber que" para mantener el imperativo y el registro de usted que se usa en el resto del capítulo.

## Test plan

- [x] `dprint check` no reporta issues sobre la línea modificada
- [x] El enlace `[shadowing]` sigue intacto